### PR TITLE
Making setting user easier

### DIFF
--- a/hadoop_common/ipc/client/client.go
+++ b/hadoop_common/ipc/client/client.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
+	"net"
+	"strings"
+	"sync"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/hortonworks/gohadoop"
 	"github.com/hortonworks/gohadoop/hadoop_common"
 	"github.com/hortonworks/gohadoop/hadoop_common/security"
 	"github.com/nu7hatch/gouuid"
-	"log"
-	"net"
-	"strings"
-	"sync"
 )
 
 type Client struct {
@@ -202,8 +203,11 @@ func writeConnectionHeader(conn *connection, authProtocol gohadoop.AuthProtocol)
 
 func writeConnectionContext(c *Client, conn *connection, connectionId *connection_id, authProtocol gohadoop.AuthProtocol) error {
 	// Create hadoop_common.IpcConnectionContextProto
-	ugi, _ := gohadoop.CreateSimpleUGIProto()
-	ipcCtxProto := hadoop_common.IpcConnectionContextProto{UserInfo: ugi, Protocol: &connectionId.protocol}
+	if c.Ugi == nil {
+		ugi, _ := gohadoop.CreateSimpleUGIProto()
+		c.Ugi = ugi
+	}
+	ipcCtxProto := hadoop_common.IpcConnectionContextProto{UserInfo: c.Ugi, Protocol: &connectionId.protocol}
 
 	// Create RpcRequestHeaderProto
 	var callId int32 = -3

--- a/hadoop_common/security/ugi.go
+++ b/hadoop_common/security/ugi.go
@@ -1,10 +1,11 @@
 package security
 
 import (
-	"github.com/hortonworks/gohadoop/hadoop_common"
 	"log"
 	"os/user"
 	"sync"
+
+	"github.com/hortonworks/gohadoop/hadoop_common"
 )
 
 /** a (very) basic UserGroupInformation implementation for storing user data/tokens,
@@ -92,5 +93,15 @@ func (ugi *UserGroupInformation) AddUserToken(token *hadoop_common.TokenProto) {
 func GetCurrentUser() *UserGroupInformation {
 	initializeCurrentUser()
 
+	return currentUserGroupInformation
+}
+
+func SetCurrentUser(userinfo *hadoop_common.UserInformationProto) *UserGroupInformation {
+	once.Do(func() {
+		currentUserGroupInformation = Allocate(
+			userinfo,
+			nil,
+		)
+	})
 	return currentUserGroupInformation
 }


### PR DESCRIPTION
These changes allow us to specifically set the user and bypass `user.Currentuser: Current not implemented` errors